### PR TITLE
config: persist settings atomically

### DIFF
--- a/Code_EXE/VoteBot(5)/VoteBot5.py
+++ b/Code_EXE/VoteBot(5)/VoteBot5.py
@@ -144,6 +144,21 @@ class VoteBot5:
         except Exception:
             return dict(self.defaults)
 
+    def _persist_config(self):
+        target_dir = self.config_path.parent
+        target_dir.mkdir(parents=True, exist_ok=True)
+        fd, temp_path = tempfile.mkstemp(prefix="config-", suffix=".json", dir=target_dir)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+                json.dump(self.config, temp_file, ensure_ascii=False, indent=4)
+            Path(temp_path).replace(self.config_path)
+        except Exception:
+            try:
+                Path(temp_path).unlink(missing_ok=True)
+            except Exception:
+                pass
+            raise
+
     def _build_vote_selectors(self, custom_selectors):
         defaults = [
             (By.CSS_SELECTOR, "a[data-action='vote']"),
@@ -1487,8 +1502,7 @@ window.chrome.runtime = {};
 
         if persist:
             try:
-                with self.config_path.open("w", encoding="utf-8") as f:
-                    json.dump(self.config, f, ensure_ascii=False, indent=4)
+                self._persist_config()
                 if notify:
                     self.log_message("Ayarlar kaydedildi.")
                     messagebox.showinfo("Ayarlar", "Ayarlar güncellendi.")


### PR DESCRIPTION
This pull request improves the way configuration files are saved in `VoteBot5.py` by introducing a safer, atomic write operation. The main change is the addition of a new `_persist_config` method that writes configuration updates to a temporary file and atomically replaces the original file, reducing the risk of data corruption.

**Configuration persistence improvements:**

* Added the `_persist_config` method to safely write configuration data by using a temporary file and atomic replacement, ensuring data integrity during saves.
* Updated the `_update_settings_from_form` method to use `_persist_config` instead of directly writing to the config file, leveraging the new safer persistence mechanism.