### PR TITLE
Normalize user-agent entries from config

### DIFF
--- a/Code_EXE/VoteBot(5)/VoteBot5.py
+++ b/Code_EXE/VoteBot(5)/VoteBot5.py
@@ -51,6 +51,7 @@ class VoteBot5:
         self.config_path = self._find_config_path()
         self.config = self._load_config()
         self.paths = self.config.setdefault("paths", {})
+        self.config["user_agents"] = self._normalize_user_agents(self.config.get("user_agents", []))
 
         self.target_url = self.config.get(
             "target_url", "https://distrokid.com/spotlight/hasanarthuraltunta/vote/"
@@ -63,6 +64,8 @@ class VoteBot5:
         self.max_errors = max(1, int(self.config.get("max_errors", 3)))
         self.parallel_workers = max(1, min(10, int(self.config.get("parallel_workers", 2))))
         self.use_selenium_manager = bool(self.config.get("use_selenium_manager", False))
+        self.use_random_user_agent = bool(self.config.get("use_random_user_agent", True))
+        self.custom_user_agents = self.config.get("user_agents") or []
         self.vote_selectors = self._build_vote_selectors(self.config.get("vote_selectors"))
         self.backoff_seconds = float(self.config.get("backoff_seconds", 5))
         self.backoff_cap_seconds = float(self.config.get("backoff_cap_seconds", 60))
@@ -86,6 +89,7 @@ class VoteBot5:
         self.failure_count = 0
         self.autoscroll_var = tk.BooleanVar(value=True)
         self.errors_only_var = tk.BooleanVar(value=False)
+        self.random_ua_var = tk.BooleanVar(value=self.use_random_user_agent)
 
         self.log_dir = self._resolve_logs_dir()
         self.logger = self._build_logger()
@@ -177,6 +181,22 @@ class VoteBot5:
         except Exception:
             pass
         return None
+
+    def _normalize_user_agents(self, agents):
+        cleaned = []
+        seen = set()
+        for ua in agents or []:
+            if not isinstance(ua, str):
+                continue
+            stripped = ua.strip()
+            if not stripped or len(stripped) < 10:
+                continue
+            lowered = stripped.lower()
+            if lowered in seen:
+                continue
+            seen.add(lowered)
+            cleaned.append(stripped)
+        return cleaned
 
     def _resolve_logs_dir(self):
         log_path = self.paths.get("logs") or "logs"


### PR DESCRIPTION
Ensure user-agent entries from the configuration are normalized for consistency and to avoid duplicates. This change improves the handling of user-agent strings by cleaning and validating them during initialization.