### PR TITLE
config: drop duplicate random user-agent keys

### DIFF
--- a/Code_EXE/VoteBot(5)/config.json
+++ b/Code_EXE/VoteBot(5)/config.json
@@ -15,8 +15,6 @@
     "use_random_user_agent": true,
     "block_images": true,
     "user_agents": [],
-    "use_random_user_agent": true,
-    "user_agents": [],
     "vote_selectors": [],
     "backoff_seconds": 5.0,
     "backoff_cap_seconds": 60.0


### PR DESCRIPTION
This pull request makes a minor cleanup to the `config.json` file by removing duplicate configuration entries, ensuring there are no redundant keys in the configuration.