### PR TITLE
fix(config): preserve ignored_config_paths from selection

### DIFF
--- a/Code_EXE/Votryx/core/config.py
+++ b/Code_EXE/Votryx/core/config.py
@@ -37,9 +37,9 @@ class ConfigurationManager:
         """
         self.base_dir = base_dir
         self.code_dir = code_dir
+        self.ignored_config_paths: List[Path] = []
         self.config_path = self._find_config_path()
         self.config = self._load_config()
-        self.ignored_config_paths: List[Path] = []
 
     def _find_config_path(self) -> Path:
         """Locate configuration file from candidate paths."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,26 @@ from Code_EXE.Votryx.core.config import ConfigurationManager
 class TestConfigurationManager:
     """Test suite for ConfigurationManager."""
 
+    def test_multiple_config_files_tracks_ignored_paths(self):
+        """Track ignored config paths when multiple candidates exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            code_dir = base_dir / "code"
+            code_dir.mkdir()
+
+            base_config_path = base_dir / "config.json"
+            code_config_path = code_dir / "config.json"
+
+            with open(base_config_path, "w") as f:
+                json.dump({"batch_size": 2}, f)
+            with open(code_config_path, "w") as f:
+                json.dump({"batch_size": 3}, f)
+
+            manager = ConfigurationManager(base_dir, code_dir)
+
+            assert manager.config_path == base_config_path
+            assert manager.ignored_config_paths == [code_config_path]
+
     def test_default_config_loaded_when_file_missing(self):
         """Test that default configuration is loaded when file doesn't exist."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
This pull request introduces a minor but important fix to the initialization order of the `ignored_config_paths` attribute in the `ConfigurationManager` class, and adds a new test to ensure correct tracking of ignored configuration paths when multiple candidate files exist.

**Testing improvements:**

* Added `test_multiple_config_files_tracks_ignored_paths` to `tests/test_config.py` to verify that `ConfigurationManager` correctly tracks ignored config paths when multiple config files are present.

**Bug fix:**

* Moved initialization of `ignored_config_paths` in `Code_EXE/Votryx/core/config.py` to occur before loading config files, ensuring it is properly set before use.