### PR TITLE
Tooling/windows installer

### DIFF
--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -1,0 +1,37 @@
+# Windows Build (EXE + Setup)
+
+These steps create a Windows EXE with PyInstaller and a setup installer with Inno Setup.
+
+## 1) Build the EXE
+
+Install dependencies:
+
+```bash
+pip install -r requirements-dev.txt
+pip install pyinstaller
+```
+
+Build:
+
+```bash
+python -m PyInstaller packaging/votryx.spec
+```
+
+Output:
+- `dist/VOTRYX/VOTRYX.exe`
+
+Optional:
+- If you have `chromedriver.exe`, place it in the repo root before building so it is bundled.
+
+## 2) Build the Setup (Inno Setup)
+
+Open `installer/votryx.iss` in Inno Setup and click **Compile**.
+
+Output:
+- `dist/installer/VOTRYX-Setup.exe`
+
+## Notes
+
+- The installer copies everything from `dist/VOTRYX/`.
+- Config falls back to `%APPDATA%\\VOTRYX\\config.json` if the install directory is not writable.
+- Welcome screen artwork is loaded from `docs/screenshots/` when present.

--- a/installer/votryx.iss
+++ b/installer/votryx.iss
@@ -1,0 +1,31 @@
+#define AppName "VOTRYX"
+#define AppVersion "1.0.0"
+#define AppPublisher "VOTRYX Contributors"
+#define AppExeName "VOTRYX.exe"
+
+[Setup]
+AppId={{3E9A2C9E-1F7A-4A1A-9AB8-3C0D01B2D11C}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+DefaultDirName={pf}\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+OutputDir=..\dist\installer
+OutputBaseFilename=VOTRYX-Setup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a desktop icon"; Flags: unchecked
+
+[Files]
+Source: "..\dist\VOTRYX\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExeName}"
+Name: "{commondesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#AppExeName}"; Description: "Launch VOTRYX"; Flags: nowait postinstall skipifsilent

--- a/packaging/votryx.spec
+++ b/packaging/votryx.spec
@@ -1,0 +1,62 @@
+# -*- mode: python ; coding: utf-8 -*-
+from pathlib import Path
+
+block_cipher = None
+
+project_root = Path(__file__).resolve().parents[1]
+app_dir = project_root / "Code_EXE" / "Votryx"
+
+datas = [
+    (str(project_root / "docs" / "screenshots"), "docs/screenshots"),
+    (str(app_dir / "config.json"), "."),
+]
+
+chromedriver = project_root / "chromedriver.exe"
+if chromedriver.exists():
+    datas.append((str(chromedriver), "."))
+
+hiddenimports = [
+    "pystray",
+    "PIL.Image",
+    "PIL.ImageTk",
+]
+
+a = Analysis(
+    [str(app_dir / "VotryxApp.py")],
+    pathex=[str(project_root)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="VOTRYX",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    name="VOTRYX",
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "flake8>=6.0.0",
     "mypy>=1.0.0",
     "isort>=5.12.0",
+    "pyinstaller>=6.0.0",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,5 +19,8 @@ pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-mock>=3.10.0
 
+# Packaging
+pyinstaller>=6.0.0
+
 # Pre-commit hooks
 pre-commit>=3.0.0


### PR DESCRIPTION
This pull request introduces Windows packaging support for the Votryx application, including PyInstaller-based EXE builds and an Inno Setup installer. It also improves configuration file handling to better support read-only install locations, and adds documentation and configuration files for the new build process.

**Windows Packaging and Installer Support:**

* Added a `packaging/votryx.spec` PyInstaller spec file to bundle the app as a Windows EXE, including support for optional `chromedriver.exe` and artwork from `docs/screenshots`.
* Added an Inno Setup script `installer/votryx.iss` to create a Windows installer that copies the bundled files and sets up desktop/start menu shortcuts.
* Added `pyinstaller` as a development dependency in both `pyproject.toml` and `requirements-dev.txt`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R24) [[2]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcR22-R24)

**Configuration File Handling Improvements:**

* Refactored `VotryxApp.py` to resolve the base directory differently when running as a frozen executable, and to support storing user config in standard OS-specific locations (`%APPDATA%` on Windows, etc.). The app now copies config to a user-writable location if the install directory is not writable. [[1]](diffhunk://#diff-74f48b4584467928e81cdeca77c970925fff633ead88d4cb730c856deafb74f8R17) [[2]](diffhunk://#diff-74f48b4584467928e81cdeca77c970925fff633ead88d4cb730c856deafb74f8L68-R69) [[3]](diffhunk://#diff-74f48b4584467928e81cdeca77c970925fff633ead88d4cb730c856deafb74f8R248-R272) [[4]](diffhunk://#diff-74f48b4584467928e81cdeca77c970925fff633ead88d4cb730c856deafb74f8R283-R297)

**Documentation:**

* Added `docs/BUILD_WINDOWS.md` with step-by-step instructions for building the Windows EXE and installer, and notes on config file fallback behavior.