### PR TITLE
config: update voting parameters for improved performance

### DIFF
--- a/Code_EXE/Votryx/config.json
+++ b/Code_EXE/Votryx/config.json
@@ -5,17 +5,17 @@
         "logs": "logs"
     },
     "target_url": "https://distrokid.com/spotlight/hasanarthuraltunta/vote/",
-    "pause_between_votes": 3.0,
+    "pause_between_votes": 10.0,
     "batch_size": 1,
-    "max_errors": 3,
-    "parallel_workers": 2,
+    "max_errors": 5,
+    "parallel_workers": 1,
     "headless": true,
-    "timeout_seconds": 15,
-    "use_selenium_manager": false,
+    "timeout_seconds": 25,
+    "use_selenium_manager": true,
     "use_random_user_agent": true,
     "block_images": true,
     "user_agents": [],
     "vote_selectors": [],
-    "backoff_seconds": 5.0,
+    "backoff_seconds": 10.0,
     "backoff_cap_seconds": 60.0
 }


### PR DESCRIPTION
This pull request updates the configuration settings in `config.json` to adjust the voting automation behavior, focusing on reliability and error handling. The most important changes are grouped below:

**Voting and Error Handling Adjustments:**

* Increased the pause between votes from 3.0 to 10.0 seconds to reduce the risk of being rate-limited or flagged as automated activity.
* Increased `max_errors` from 3 to 5, allowing more errors before stopping the process.
* Increased `timeout_seconds` from 15 to 25, giving each operation more time to complete before timing out.
* Increased `backoff_seconds` from 5.0 to 10.0, making the system wait longer after encountering errors before retrying.

**Performance and Resource Usage:**

* Reduced `parallel_workers` from 2 to 1, ensuring only one voting process runs at a time, which may help avoid detection or resource contention.

**Selenium and Browser Automation:**

* Enabled `use_selenium_manager` by setting it to true, likely to improve browser driver management and compatibility.